### PR TITLE
Fix OrganPipe data generation

### DIFF
--- a/benchmark/source/mpqsort.cpp
+++ b/benchmark/source/mpqsort.cpp
@@ -114,7 +114,7 @@ struct OrganpipeOrderVectorFixture : public RandomVectorFixture<T, Size, From, T
         this->AllocateVector();
         this->FillVectorRandom();
 
-        auto end_middle = this->vec.size() / 2 + this->vec.size() & 1;
+        auto end_middle = this->vec.size() / 2 + (this->vec.size() & 1);
 
         __gnu_parallel::sort(this->vec.begin(), this->vec.begin() + end_middle,
                              __gnu_parallel::balanced_quicksort_tag());


### PR DESCRIPTION
The division (/) and addition (+) operators have higher precedence than the bitwise AND (&) operator (https://en.cppreference.com/w/cpp/language/operator_precedence). Therefore, the expression:
```cpp
auto end_middle = this->vec.size() / 2 + this->vec.size() & 1;
```
Is effectively interpreted as follows:
```cpp
auto end_middle = (this->vec.size() / 2 + this->vec.size()) & 1;
```
So, the bitwise AND (&) operation is applied to the entire sum, which means the resulting value of the end_middle variable will be 1 or 0. A simple fix here is to add parenthesis:
```cpp
auto end_middle = this->vec.size() / 2 + (this->vec.size() & 1);
```
